### PR TITLE
Optional dependency fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,5 +103,9 @@ modifyPom {
                 name 'Paweł Lesiecki'
             }
         }
+
+        project.optionalDeps.each { dep ->
+            dependencies.find { it.artifactId == dep.name }.optional = true
+        }
     }
 }


### PR DESCRIPTION
Currently optional dependencies are not marked as optional in pom (https://repo1.maven.org/maven2/pl/allegro/tech/boot/spring-boot-starter-handlebars/0.1.0/spring-boot-starter-handlebars-0.1.0.pom)
This should fix the problem. 
This change can be tested using `./gradlew install` and checking `build/poms/pom-default.xml`. 
