### PR TITLE
add option to set infiniteLoops

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ handlebars.cache: true
 handlebars.registerMessageHelper: true
 handlebars.failOnMissingFile: false
 handlebars.prettyPrint: false
+handlebars.infiniteLoops: false
 ```
 NOTE: `handlebars-guava-cache` is used as template cache implementation.
 

--- a/src/main/java/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsAutoConfiguration.java
+++ b/src/main/java/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsAutoConfiguration.java
@@ -86,4 +86,16 @@ public class HandlebarsAutoConfiguration {
             handlebarsViewResolver.getHandlebars().prettyPrint(true);
         }
     }
+
+    @Configuration
+    @ConditionalOnProperty("handlebars.infiniteLoops")
+    protected static class InfiniteLoopsConfiguration {
+        @Autowired
+        private HandlebarsViewResolver handlebarsViewResolver;
+
+        @PostConstruct
+        public void setInfiniteLoops() {
+            handlebarsViewResolver.getHandlebars().infiniteLoops(true);
+        }
+    }
 }

--- a/src/test/groovy/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsAutoConfigurationSpec.groovy
+++ b/src/test/groovy/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsAutoConfigurationSpec.groovy
@@ -121,6 +121,17 @@ class HandlebarsAutoConfigurationSpec extends Specification {
         resolver.handlebars.prettyPrint
     }
 
+    def 'should configure handlebars with infinite loops'() {
+        given:
+        'register and refresh context'('handlebars.infiniteLoops:true')
+
+        when:
+        def resolver = context.getBean(HandlebarsViewResolver)
+
+        then:
+        resolver.handlebars.infiniteLoops
+    }
+
     def 'should configure handlebars with custom template loader'() {
         given:
         context.register(CustomConfiguration)


### PR DESCRIPTION
This pull requests adds the infiniteLoops option as it is available in https://github.com/jknack/handlebars.java

> Allow Infinite loops
>
> By default, Handlebars.java doesn't allow a partial to call itself (directly or indirectly). You can change this > by setting the: Handlebars.inifiteLoops(true), but watch out for a StackOverflowError. 