### PR TITLE
add option to set bindI18nToMessageSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ handlebars.suffix: .hbs
 handlebars.cache: true
 handlebars.registerMessageHelper: true
 handlebars.failOnMissingFile: false
+handlebars.bindI18nToMessageSource: false
 handlebars.prettyPrint: false
 handlebars.infiniteLoops: false
 ```

--- a/src/main/java/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsProperties.java
+++ b/src/main/java/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsProperties.java
@@ -26,6 +26,7 @@ public class HandlebarsProperties extends AbstractTemplateViewResolverProperties
 
     private Boolean registerMessageHelper = true;
     private Boolean failOnMissingFile = false;
+    private Boolean bindI18nToMessageSource = false;
 
     private final HandlebarsValueResolversProperties valueResolversProperties;
 
@@ -53,6 +54,7 @@ public class HandlebarsProperties extends AbstractTemplateViewResolverProperties
         resolver.setValueResolvers(listToArray(valueResolvers));
         resolver.setRegisterMessageHelper(registerMessageHelper);
         resolver.setFailOnMissingFile(failOnMissingFile);
+        resolver.setBindI18nToMessageSource(bindI18nToMessageSource);
     }
 
     public void setRegisterMessageHelper(Boolean registerMessageHelper) {
@@ -61,6 +63,10 @@ public class HandlebarsProperties extends AbstractTemplateViewResolverProperties
 
     public void setFailOnMissingFile(Boolean failOnMissingFile) {
         this.failOnMissingFile = failOnMissingFile;
+    }
+
+    public void setBindI18nToMessageSource(Boolean bindI18nToMessageSource) {
+        this.bindI18nToMessageSource = bindI18nToMessageSource;
     }
 
     private void addValueResolverIfNeeded(List<ValueResolver> resolvers, boolean property, ValueResolver resolver) {

--- a/src/test/groovy/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsAutoConfigurationSpec.groovy
+++ b/src/test/groovy/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsAutoConfigurationSpec.groovy
@@ -41,6 +41,7 @@ class HandlebarsAutoConfigurationSpec extends Specification {
         resolver.handlebars.loader instanceof SpringTemplateLoader
         resolver.helper('message')
         !resolver.failOnMissingFile
+        !resolver.bindI18nToMessageSource
     }
 
     def 'not enabled handlebars'() {

--- a/src/test/groovy/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsPropertiesSpec.groovy
+++ b/src/test/groovy/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsPropertiesSpec.groovy
@@ -23,6 +23,7 @@ class HandlebarsPropertiesSpec extends Specification {
         viewResolver.valueResolvers.contains(MapValueResolver.INSTANCE)
         viewResolver.registerMessageHelper
         !viewResolver.failOnMissingFile
+        !viewResolver.bindI18nToMessageSource
     }
 
     def 'should not register message helper'() {
@@ -51,6 +52,20 @@ class HandlebarsPropertiesSpec extends Specification {
 
         then:
         viewResolver.failOnMissingFile
+    }
+
+    def 'should bind i18n to message source'() {
+        given:
+        def properties = new HandlebarsProperties(new HandlebarsValueResolversProperties())
+
+        and:
+        properties.bindI18nToMessageSource = true
+
+        when:
+        properties.applyToViewResolver(viewResolver)
+
+        then:
+        viewResolver.bindI18nToMessageSource
     }
 
     def 'should set value resolvers based on configuration'() {


### PR DESCRIPTION
Adds ability to configure bindI18nToMessageSource option.  This feature doesn't appear in handlebars.java docs, but was added a while ago in this commit: https://github.com/jknack/handlebars.java/commit/bf2c1307199f5923f173908090837171c12b824f