### PR TITLE
Fix build process and CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 after_success:
 - ./gradlew jacocoTestReport coveralls

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ task wrapper(type: Wrapper) { gradleVersion = '2.9' }
 checkstyle { toolVersion = '6.4.1' }
 
 codenarc {
-    toolVersion = '0.23'
+    toolVersion = '1.0'
     configFile = new File("${projectDir}/config/codenarc/test-rules.groovy")
 }
 

--- a/config/codenarc/StarterRuleSet-AllRulesByCategory.groovy
+++ b/config/codenarc/StarterRuleSet-AllRulesByCategory.groovy
@@ -307,7 +307,6 @@ ruleset {
     SerializableClassMustDefineSerialVersionUID
 
     // rulesets/size.xml
-    AbcComplexity   // DEPRECATED: Use the AbcMetric rule instead. Requires the GMetrics jar
     AbcMetric   // Requires the GMetrics jar
     ClassSize
     CrapMetric   // Requires the GMetrics jar and a Cobertura coverage file


### PR DESCRIPTION
This PR fixed build process and CI. 
Last build was using trusty  https://travis-ci.org/github/allegro/handlebars-spring-boot-starter/builds/42144200. Currently we are using xenial https://travis-ci.org/github/allegro/handlebars-spring-boot-starter/builds/703486795, which does not offer oraclejdk8. 

Updating codenarc  to 1.0 fixes error:
```
Execution failed for task ':codenarcTest'.
> java.lang.NoClassDefFoundError: groovy/text/SimpleTemplateEngine
```
(solution from https://discuss.gradle.org/t/sudden-issue-with-gradle-3-5-1-and-codenarc/30064/4). 