### PR TITLE
Missing imports of TestPropertyValues

### DIFF
--- a/src/test/groovy/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsAutoConfigurationSpec.groovy
+++ b/src/test/groovy/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsAutoConfigurationSpec.groovy
@@ -9,6 +9,7 @@ import com.github.jknack.handlebars.io.ClassPathTemplateLoader
 import com.github.jknack.handlebars.springmvc.HandlebarsViewResolver
 import com.github.jknack.handlebars.springmvc.SpringTemplateLoader
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
+import org.springframework.boot.test.util.TestPropertyValues
 import org.springframework.context.annotation.Bean
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse

--- a/src/test/groovy/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsCustomHelpersAutoConfigurationSpec.groovy
+++ b/src/test/groovy/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsCustomHelpersAutoConfigurationSpec.groovy
@@ -1,6 +1,7 @@
 package pl.allegro.tech.boot.autoconfigure.handlebars
 
 import com.github.jknack.handlebars.springmvc.HandlebarsViewResolver
+import org.springframework.boot.test.util.TestPropertyValues
 import org.springframework.mock.web.MockServletContext
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext
 import spock.lang.Specification

--- a/src/test/groovy/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsHelpersAutoConfigurationSpec.groovy
+++ b/src/test/groovy/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsHelpersAutoConfigurationSpec.groovy
@@ -1,6 +1,7 @@
 package pl.allegro.tech.boot.autoconfigure.handlebars
 
 import com.github.jknack.handlebars.springmvc.HandlebarsViewResolver
+import org.springframework.boot.test.util.TestPropertyValues
 import org.springframework.mock.web.MockServletContext
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext
 import spock.lang.Specification

--- a/test-dependencies/src/test/groovy/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsHelpersDependenciesSpec.groovy
+++ b/test-dependencies/src/test/groovy/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsHelpersDependenciesSpec.groovy
@@ -1,6 +1,7 @@
 package pl.allegro.tech.boot.autoconfigure.handlebars
 
 import com.github.jknack.handlebars.springmvc.HandlebarsViewResolver
+import org.springframework.boot.test.util.TestPropertyValues
 import org.springframework.mock.web.MockServletContext
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext
 import spock.lang.Specification


### PR DESCRIPTION
Currently tests cannot be run using Gradle. The problem was introduced in https://github.com/allegro/handlebars-spring-boot-starter/pull/34. We need two elements required to run tests:
- add `test { useJUnitPlatform() }` to `build.gradle` (will be added in https://github.com/allegro/handlebars-spring-boot-starter/pull/36 or in a separate PR)
- add missing imports (this PR)