### PR TITLE
Fix circular reference between beans

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ ext {
     jodaVersion = '2.10.10'
     spockVersion = '2.0-groovy-3.0'
     handlebarsVersion = '4.2.0'
-    springBootVersion = '2.5.3'
+    springBootVersion = '2.6.1'
 }
 
 allprojects {

--- a/src/main/java/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsAutoConfiguration.java
+++ b/src/main/java/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsAutoConfiguration.java
@@ -40,6 +40,15 @@ public class HandlebarsAutoConfiguration {
 
     @Configuration
     protected static class HandlebarsCacheConfiguration {
+        @Bean
+        @ConditionalOnMissingBean
+        public TemplateCache templateCache() {
+            return new GuavaTemplateCache(newBuilder().<TemplateSource, Template>build());
+        }
+    }
+
+    @Configuration
+    protected static class HandlebarsCachingStrategyConfiguration {
         @Autowired
         private HandlebarsViewResolver handlebarsViewResolver;
 
@@ -51,12 +60,6 @@ public class HandlebarsAutoConfiguration {
             if (handlebarsViewResolver.isCache()) {
                 handlebarsViewResolver.getHandlebars().with(templateCacheInstance);
             }
-        }
-
-        @Bean
-        @ConditionalOnMissingBean
-        public TemplateCache templateCache() {
-            return new GuavaTemplateCache(newBuilder().<TemplateSource, Template>build());
         }
     }
 


### PR DESCRIPTION
Hi,

starting with spring-boot 2.6 circular references are prohibited by default. See: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes#circular-references-prohibited-by-default

Our application didn't start with the following message:

```
***************************
APPLICATION FAILED TO START
***************************

Description:

The dependencies of some of the beans in the application context form a cycle:

┌──->──┐
|  pl.allegro.tech.boot.autoconfigure.handlebars.HandlebarsAutoConfiguration$HandlebarsCacheConfiguration (field private com.github.jknack.handlebars.cache.TemplateCache pl.allegro.tech.boot.autoconfigure.handlebars.HandlebarsAutoConfiguration$HandlebarsCacheConfiguration.templateCacheInstance)
└──<-──┘


Action:

Relying upon circular references is discouraged and they are prohibited by default. Update your application to remove the dependency cycle between beans. As a last resort, it may be possible to break the cycle automatically by setting spring.main.allow-circular-references to true.
```

This pull request fixes this.