### PR TITLE
Version 0.3.4 in Usage section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-    compile 'pl.allegro.tech.boot:handlebars-spring-boot-starter:0.3.3'
+    compile 'pl.allegro.tech.boot:handlebars-spring-boot-starter:0.3.4'
 }
 ```
 


### PR DESCRIPTION
Version 0.3.4 is available in https://repo1.maven.org/maven2/pl/allegro/tech/boot/handlebars-spring-boot-starter/. 