### PR TITLE
Run CI on pull request

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -3,7 +3,7 @@
 
 name: Java CI with Gradle
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
CI is not triggered for pull requests (created from forks) ([example](https://github.com/allegro/handlebars-spring-boot-starter/pull/43)). This PR enables CI for pull requests. 