### PR TITLE
Update build badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Spring Boot Starter Handlebars
 ====
 
-[![Build Status](https://travis-ci.org/allegro/handlebars-spring-boot-starter.svg?branch=master)](https://travis-ci.org/allegro/handlebars-spring-boot-starter)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/allegro/handlebars-spring-boot-starter/gradle.yml)](https://github.com/allegro/handlebars-spring-boot-starter/actions/workflows/gradle.yml)
 [![Coverage Status](https://coveralls.io/repos/allegro/handlebars-spring-boot-starter/badge.svg)](https://coveralls.io/r/allegro/handlebars-spring-boot-starter)
 ![Maven Central](https://img.shields.io/maven-central/v/pl.allegro.tech.boot/handlebars-spring-boot-starter.svg)
 


### PR DESCRIPTION
Replace Travis CI badge with GitHub Action CI badge. 

Before:
![Zrzut ekranu 2023-09-28 o 17 59 58](https://github.com/allegro/handlebars-spring-boot-starter/assets/1526000/1bdaeef5-4285-4bb1-8b7a-de80905066f4)

After:
![Zrzut ekranu 2023-09-28 o 18 01 00](https://github.com/allegro/handlebars-spring-boot-starter/assets/1526000/c5509fe5-4da3-4665-8499-5420c7c5ddd3)
