### PR TITLE
Upgrade Handlebars to 4.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,10 @@ Add any handlebars helper to dependencies and you can start using it.
 dependencies {
     compile 'com.github.jknack:handlebars-helpers:4.2.0',
             'com.github.jknack:handlebars-jackson2:4.2.0',
-            'com.github.jknack:handlebars-humanize:4.2.0',
-            'com.github.jknack:handlebars-markdown:4.2.0'
+            'com.github.jknack:handlebars-humanize:4.2.0'
 }
 ```
-NOTE: Jackson2Helper and MarkdownHelper will register with name `json` and `md` respectively.
+NOTE: Jackson2Helper will register with name `json`.
 Every other helper will register with its default name.
 
 More information about available helpers can be found on

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ project.version = scmVersion.version
 ext {
     jodaVersion = '2.10.10'
     spockVersion = '2.0-groovy-3.0'
-    handlebarsVersion = '4.2.0'
+    handlebarsVersion = '4.3.1'
     springBootVersion = '2.6.1'
 }
 
@@ -39,6 +39,10 @@ allprojects {
     }
     apply plugin: 'groovy'
     sourceCompatibility = 1.8
+
+    test {
+        useJUnitPlatform()
+    }
 }
 dependencies {
     compile 'org.springframework.boot:spring-boot-starter-web:' + springBootVersion,
@@ -48,7 +52,6 @@ dependencies {
     compile 'joda-time:joda-time:' + jodaVersion, optional
     compile 'com.github.jknack:handlebars-helpers:' + handlebarsVersion, optional
     compile 'com.github.jknack:handlebars-humanize:' + handlebarsVersion, optional
-    compile 'com.github.jknack:handlebars-markdown:' + handlebarsVersion, optional
     compile 'com.github.jknack:handlebars-jackson2:' + handlebarsVersion, optional
     compile 'org.springframework.boot:spring-boot-configuration-processor:' + springBootVersion, optional
 
@@ -89,10 +92,6 @@ jacocoTestReport {
         xml.enabled = true
         html.enabled = true
     }
-}
-
-test {
-    useJUnitPlatform()
 }
 
 java {

--- a/src/main/java/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsHelpersAutoConfiguration.java
+++ b/src/main/java/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsHelpersAutoConfiguration.java
@@ -2,7 +2,6 @@ package pl.allegro.tech.boot.autoconfigure.handlebars;
 
 import com.github.jknack.handlebars.HumanizeHelper;
 import com.github.jknack.handlebars.Jackson2Helper;
-import com.github.jknack.handlebars.MarkdownHelper;
 import com.github.jknack.handlebars.helper.AssignHelper;
 import com.github.jknack.handlebars.helper.IncludeHelper;
 import com.github.jknack.handlebars.helper.JodaHelper;
@@ -63,19 +62,6 @@ public class HandlebarsHelpersAutoConfiguration {
         @PostConstruct
         public void registerHelper() {
             handlebarsViewResolver.registerHelper("include", IncludeHelper.INSTANCE);
-        }
-    }
-
-    @Configuration
-    @ConditionalOnClass(MarkdownHelper.class)
-    static class MarkdownHelperAutoConfiguration {
-
-        @Autowired
-        private HandlebarsViewResolver handlebarsViewResolver;
-
-        @PostConstruct
-        public void registerHelper() {
-            handlebarsViewResolver.registerHelper("md", MarkdownHelper.INSTANCE);
         }
     }
 

--- a/src/test/groovy/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsPropertiesSpec.groovy
+++ b/src/test/groovy/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsPropertiesSpec.groovy
@@ -18,7 +18,7 @@ class HandlebarsPropertiesSpec extends Specification {
         properties.applyToMvcViewResolver(viewResolver)
 
         then:
-        viewResolver.valueResolvers.length == 2
+        viewResolver.valueResolvers.size() == 2
         viewResolver.valueResolvers.contains(JavaBeanValueResolver.INSTANCE)
         viewResolver.valueResolvers.contains(MapValueResolver.INSTANCE)
         viewResolver.registerMessageHelper

--- a/test-dependencies/src/test/groovy/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsHelpersDependenciesSpec.groovy
+++ b/test-dependencies/src/test/groovy/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsHelpersDependenciesSpec.groovy
@@ -32,6 +32,5 @@ class HandlebarsHelpersDependenciesSpec extends Specification {
         resolver.helper('assign')
         resolver.helper('include')
         resolver.helper('camelize')
-        resolver.helper('md')
     }
 }


### PR DESCRIPTION
Fixes https://github.com/allegro/handlebars-spring-boot-starter/issues/47. 

`handlebars-markdown` was removed (https://github.com/jknack/handlebars.java/issues/900) in `4.3.0` and this PR removes usage of `handlebars-markdown`. 