### PR TITLE
Remove precise package version from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-    compile 'pl.allegro.tech.boot:handlebars-spring-boot-starter:0.3.4'
+    compile 'pl.allegro.tech.boot:handlebars-spring-boot-starter:$version'
 }
 ```
 


### PR DESCRIPTION
After removing precise version we are not required to update version after every release. 