### PR TITLE
Update dependencies (Spring Boot 2.7 and other)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,10 +27,10 @@ project.group = 'pl.allegro.tech.boot'
 project.version = scmVersion.version
 
 ext {
-    jodaVersion = '2.10.10'
-    spockVersion = '2.0-groovy-3.0'
+    jodaVersion = '2.12.5'
+    spockVersion = '2.3-groovy-3.0'
     handlebarsVersion = '4.3.1'
-    springBootVersion = '2.6.1'
+    springBootVersion = '2.7.16'
 }
 
 allprojects {


### PR DESCRIPTION
2.7.16 is the latest version of Spring Boot 2.x. Currently we are not able to update to Spring Boot 3 https://github.com/allegro/handlebars-spring-boot-starter/issues/46. 