### PR TITLE
Prevent compilation errors in Codenarc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ codenarc {
 
 codenarcTest {
     ignoreFailures true
+    compilationClasspath = codenarcMain.compilationClasspath + sourceSets.test.compileClasspath + sourceSets.test.output
 }
 
 pmd {


### PR DESCRIPTION
Before:
```sh
./gradlew clean check
Compilation failed for [CustomCompilerPhaseSourceDecorator[SourceFile[/Users/marcin.mielnicki/workspaces/github/handlebars-spring-boot-starter/src/test/groovy/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsTemplateAvailabilityProviderSpec.groovy]]]; org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
None: 4: unable to resolve class org.springframework.mock.env.MockEnvironment
 @ line 4, column 1.
   import org.springframework.mock.env.MockEnvironment
   ^

None: 5: unable to resolve class spock.lang.Specification
 @ line 5, column 1.
   import spock.lang.Specification
   ^

None: 3: unable to resolve class org.springframework.core.io.DefaultResourceLoader
 @ line 3, column 1.
   import org.springframework.core.io.DefaultResourceLoader
   ^

None: 9: unable to resolve class HandlebarsTemplateAvailabilityProvider
 @ line 9, column 20.
       def provider = new HandlebarsTemplateAvailabilityProvider()
                      ^

None: 7: unable to resolve class spock.lang.Specification
 @ line 7, column 1.
   class HandlebarsTemplateAvailabilityProviderSpec extends Specification {
   ^

None: 9: unable to resolve class HandlebarsTemplateAvailabilityProvider
 @ line 9, column 20.
       def provider = new HandlebarsTemplateAvailabilityProvider()
                      ^

None: 10: unable to resolve class org.springframework.core.io.DefaultResourceLoader
 @ line 10, column 26.
       def resourceLoader = new DefaultResourceLoader()
                            ^

None: 11: unable to resolve class org.springframework.mock.env.MockEnvironment
 @ line 11, column 23.
       def environment = new MockEnvironment()
                         ^

8 errors

// and more errors
```

After:
```sh
./gradlew clean check
Starting a Gradle Daemon, 1 incompatible and 3 stopped Daemons could not be reused, use --status for details

> Configure project :
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
The Cobertura XML file [null] is not accessible; skipping this rule

> Task :codenarcTest
CodeNarc rule violations were found. See the report at: file:///Users/marcin.mielnicki/workspaces/github/handlebars-spring-boot-starter/build/reports/codenarc/test.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.6.3/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 14s
14 actionable tasks: 14 executed
```

Solution based on https://github.com/CodeNarc/CodeNarc/issues/123#issuecomment-773568162