### PR TITLE
Fix assertion in HandlebarsHelpersAutoConfigurationSpec

### DIFF
--- a/src/test/groovy/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsHelpersAutoConfigurationSpec.groovy
+++ b/src/test/groovy/pl/allegro/tech/boot/autoconfigure/handlebars/HandlebarsHelpersAutoConfigurationSpec.groovy
@@ -28,11 +28,10 @@ class HandlebarsHelpersAutoConfigurationSpec extends Specification {
         def resolver = context.getBean(HandlebarsViewResolver)
 
         expect:
-        resolver.with {
+        with(resolver) {
             helper('json')
             helper('assign')
             helper('camelize')
-            helper('md')
             helper('include')
             helper('stringFormat')
         }


### PR DESCRIPTION
This PR fixes assertion in test. `spock.lang.Specification#with` should be used instead of `org.codehaus.groovy.runtime.DefaultGroovyMethods#with`. Moreover markdown helper is removed from assertion (see https://github.com/allegro/handlebars-spring-boot-starter/pull/50). 